### PR TITLE
Hide confirmations when chatting with NPCs

### DIFF
--- a/AnnoyingPopupRemover.lua
+++ b/AnnoyingPopupRemover.lua
@@ -261,7 +261,7 @@ end
 -- popup is required, state and ConfState are optional
 function APR:TogglePopup(popup, state, ConfState)
 
-	DebugPrint("in TogglePopup, popup = " .. popup .. ", state is " .. (state and state or "nil") .. ", ConfState is " .. (ConfState == nil and "nil" or (ConfState and "true" or "false")))
+	DebugPrint("in TogglePopup, popup = ", popup, ", state is ", state, ", ConfState is ", (ConfState == nil and "nil" or (ConfState and "true" or "false")))
 
 	-- Check if a confirmation message should be printed. This is only needed when a change is made from the command line, not from the config UI.
 	local ShowConf = APR.PRINT_CONFIRMATION
@@ -279,7 +279,7 @@ function APR:TogglePopup(popup, state, ConfState)
 	-- We'll follow the game protocol of using the word "delete", but accept "destroy" as well.
 	if "destroy" == popup then popup = "delete" end
 
-	DebugPrint("in TogglePopup, After replacing, popup is " .. popup)
+	DebugPrint("in TogglePopup, After replacing, popup is ", popup)
 
 	-- Get the settings for the selected popup
 	local Settings = APR.Modules[popup]
@@ -299,7 +299,7 @@ function APR:TogglePopup(popup, state, ConfState)
 				Settings.HidePopup(ShowConf)
 			else
 				-- error, bad programmer, no cookie!
-				DebugPrint("Error in APR:TogglePopup: unknown state " .. state .. " for popup type " .. PreReplacePopup .. " passed in.")
+				DebugPrint("Error in APR:TogglePopup: unknown state ", state, " for popup type ", PreReplacePopup, " passed in.")
 				return false
 			end
 		else
@@ -312,7 +312,7 @@ function APR:TogglePopup(popup, state, ConfState)
 		end
 	else
 		-- error, bad programmer, no cookie!
-		DebugPrint("Error in APR:TogglePopup: unknown popup type " .. PreReplacePopup .. " passed in. (Parsed as " .. popup .. " after replacement.)")
+		DebugPrint("Error in APR:TogglePopup: unknown popup type ", PreReplacePopup, " passed in. (Parsed as ", popup, " after replacement.)")
 		return false
 	end
 end -- APR:TogglePopup()
@@ -330,7 +330,7 @@ end -- APR:SetDebug()
 
 
 function APR:ToggleStartupMessage(mode, ConfState)
-	DebugPrint("in ToggleStartupMessage, mode = " .. mode .. ", ConfState is " .. (ConfState == nil and "nil" or (ConfState and "true" or "false")))
+	DebugPrint("in ToggleStartupMessage, mode = ", mode, ", ConfState is ", (ConfState == nil and "nil" or (ConfState and "true" or "false")))
 
 	-- Check if a confirmation message should be printed. This is only needed when a change is made from the command line, not from the config UI.
 	local ShowConf = APR.PRINT_CONFIRMATION
@@ -346,7 +346,7 @@ function APR:ToggleStartupMessage(mode, ConfState)
 		if ShowConf then ChatPrint(L["Startup announcement message will NOT printed in your chat frame at login."]) end
 	else
 		-- error, bad programmer, no cookie!
-		DebugPrint("Error in APR:ToggleStartupMessage: unknown mode " .. mode .. " passed in.")
+		DebugPrint("Error in APR:ToggleStartupMessage: unknown mode ", mode, " passed in.")
 		return false
 	end
 end -- APR:ToggleStartupMessage()
@@ -359,7 +359,7 @@ end -- APR:ToggleStartupMessage()
 -- On-load handler for addon initialization.
 function APR.Events:PLAYER_LOGIN(...)
 	DebugPrint("In PLAYER_LOGIN")
-	DebugPrint("Detected client is " .. (APR.IsClassic and "Classic" or "Retail"))
+	DebugPrint("Detected client is ", (APR.IsClassicEra and "Classic Era" or APR.IsClassic and "Classic Non-Era" or "Retail"))
 
 	-- Load the saved variables, or initialize if they don't exist yet.
 	if APR_DB then
@@ -369,9 +369,9 @@ function APR.Events:PLAYER_LOGIN(...)
 			if not APR.IsClassic or Settings.WorksInClassic then
 				if nil == APR_DB[Settings.DBName] then
 					APR_DB[Settings.DBName] = Settings.DBDefaultValue
-					DebugPrint(Settings.DBName .. " in APR_DB initialized to " .. MakeString(Settings.DBDefaultValue) .. ".")
+					DebugPrint(Settings.DBName, " in APR_DB initialized to ", MakeString(Settings.DBDefaultValue), ".")
 				else
-					DebugPrint(Settings.DBName .. " in APR_DB exists as " .. MakeString(Settings.DBDefaultValue) .. ".")
+					DebugPrint(Settings.DBName, " in APR_DB exists as ", MakeString(Settings.DBDefaultValue), ".")
 				end
 			end
 		end
@@ -399,7 +399,7 @@ function APR.Events:PLAYER_LOGIN(...)
 
 			-- Hide the dialogs the user has selected.
 			-- In this scenario, the DB variable may already be true, but the dialog has not yet been hidden. So, we pass APR.FORCE_HIDE_DIALOG to forcibly hide the dialogs.
-			DebugPrint("At load, " .. Settings.DBName .. " is " .. MakeString(APR.DB[Settings.DBName]))
+			DebugPrint("At load, ", Settings.DBName, " is ", MakeString(APR.DB[Settings.DBName]))
 			if APR.DB[Settings.DBName] then
 				Settings.HidePopup(APR.NO_CONFIRMATION, APR.FORCE_HIDE_DIALOG)
 			end
@@ -407,7 +407,7 @@ function APR.Events:PLAYER_LOGIN(...)
 	end -- processing loaded settings
 
 	-- Announce our load.
-	DebugPrint("APR.DB.PrintStartupMessage is " .. MakeString(APR.DB.PrintStartupMessage))
+	DebugPrint("APR.DB.PrintStartupMessage is ", MakeString(APR.DB.PrintStartupMessage))
 	if APR.DB.PrintStartupMessage then
 		APR:PrintVersion(true)
 	end

--- a/AnnoyingPopupRemover.lua
+++ b/AnnoyingPopupRemover.lua
@@ -110,6 +110,14 @@ APR.OptionsTable = {
 			guiHidden = true,
 			order = 800,
 		}, -- status
+
+		version = {
+			name = L["Print the APR version and help summary"],
+			type = "execute",
+			func = function() APR:PrintVersion() end,
+			guiHidden = true,
+			order = 801,
+		}, -- status
 	} -- args
 } -- APR.OptionsTable
 
@@ -175,6 +183,10 @@ function APR:HandleAceSettingsChange(value, AceInfo)
 	elseif "status" == option then
 		APR:PrintStatus()
 
+	-- Print version if requested
+	elseif "version" == option then
+		APR:PrintVersion()
+
 	end -- if
 end -- APR:HandleAceSettingsChange()
 
@@ -231,6 +243,14 @@ function APR:PrintStatus(popup)
 		APR:PrintStatusSingle(popup)
 	end
 end -- APR:PrintStatus()
+
+
+function APR:PrintVersion(PrintLoadMessage)
+	local message = APR.Version .. " " .. L["loaded"] .. "."
+	if PrintLoadMessage then message = message .. " " .. L["For help and options, type /apr"] end
+
+	ChatPrint( message )
+end
 
 
 --#########################################
@@ -389,7 +409,7 @@ function APR.Events:PLAYER_LOGIN(...)
 	-- Announce our load.
 	DebugPrint("APR.DB.PrintStartupMessage is " .. MakeString(APR.DB.PrintStartupMessage))
 	if APR.DB.PrintStartupMessage then
-		ChatPrint(APR.Version .. " " .. L["loaded"] .. ". " .. L["For help and options, type /apr"])
+		APR:PrintVersion(true)
 	end
 
 end -- APR.Events:PLAYER_LOGIN()

--- a/AnnoyingPopupRemover.toc
+++ b/AnnoyingPopupRemover.toc
@@ -47,5 +47,6 @@ module_quest.lua
 module_undercut.lua
 module_dragonriding.lua
 module_workorder.lua
+module_gossip.lua
 
 AnnoyingPopupRemover.lua

--- a/Curse description in markup.md
+++ b/Curse description in markup.md
@@ -16,6 +16,7 @@ Ever get annoyed by those pop-ups in the game that make you feel like it's an ov
 - Abandoning a quest.
 - Buying a dragonriding talent.
 - Crafting a profession work order using your own reagents or materials.
+- Accepting a teleport to the Darkmoon Faire.
 
 In addition, it simplifies the following dialog:
 
@@ -27,9 +28,9 @@ You can change your settings using the standard addon options screen, or using t
 The easiest way to configure the addon is through the standard Blizzard addon interface. If you want to use the command line instead, type `/apr` to see your options.
 
 ## Version Notes
-Version 17 adds the option to hide the pop-up when crafting a profession work order using your own reagents or materials.
+Version 18 adds the option to hide the pop-up when you request a teleport to the Darkmoon Faire from a Darkmoon Faire Mystic Mage.
 
-Version 16 adds the option to hide the pop-up when you abandon a quest.
+Version 17 adds the option to hide the pop-up when crafting a profession work order using your own reagents or materials.
 
 So far, I've tested this add-on in a variety of situations, and it seems to work well for all scenarios I've encountered. If you encounter any errors, PLEASE [open an issue](https://github.com/KyrosKrane/AnnoyingPopupRemover/issues) on Github including the FULL error message and what you were doing when it happened. I also need to know whether you were solo, in a group, or in a raid; and what the group/raid loot settings were (e.g., master loot, NBG, etc., and what the loot threshold was).
 

--- a/Curse description in markup.md
+++ b/Curse description in markup.md
@@ -16,7 +16,7 @@ Ever get annoyed by those pop-ups in the game that make you feel like it's an ov
 - Abandoning a quest.
 - Buying a dragonriding talent.
 - Crafting a profession work order using your own reagents or materials.
-- Chatting with NPCs, such as teleporting to the Darkmoon Faire or starting some pet battles.
+- Chatting with NPCs, such as teleporting to the Darkmoon Faire, healing pets at a stable master, or starting pet battles.
 
 In addition, it simplifies the following dialog:
 
@@ -35,6 +35,8 @@ Version 17 adds the option to hide the pop-up when crafting a profession work or
 So far, I've tested this add-on in a variety of situations, and it seems to work well for all scenarios I've encountered. If you encounter any errors, PLEASE [open an issue](https://github.com/KyrosKrane/AnnoyingPopupRemover/issues) on Github including the FULL error message and what you were doing when it happened. I also need to know whether you were solo, in a group, or in a raid; and what the group/raid loot settings were (e.g., master loot, NBG, etc., and what the loot threshold was).
 
 ## Known errors
+I tried to include the most common stable masters and pet battles, but I might have missed some. If you see a popup asking you to confirm healing your pets at a stable master or to confirm starting a pet battle, please report it in [my Discord server](https://discord.gg/YRBDrxQ). I'll need to know your player faction (Horde/Alliance) and the name of the pet tamer or stable master you got the popup from.
+
 I've had reports that the addon can interfere with picking up bind-on-pickup items on Classic Era and Wrath Classic servers. Reported examples are fishing up Old Ironjaw or Old Crafty. I've never been able to reproduce this properly, so I don't know what the root cause is or how to fix it. If you are trying for those fish, I suggest disabling the options for looting bind-on-pickup items.
 
 I don't have a toon high enough to test thoroughly on WoW Classic, so if you find any errors, please report them in the comments here, or (preferably) [open an issue](https://github.com/KyrosKrane/AnnoyingPopupRemover/issues) on Github.

--- a/Curse description in markup.md
+++ b/Curse description in markup.md
@@ -16,7 +16,7 @@ Ever get annoyed by those pop-ups in the game that make you feel like it's an ov
 - Abandoning a quest.
 - Buying a dragonriding talent.
 - Crafting a profession work order using your own reagents or materials.
-- Accepting a teleport to the Darkmoon Faire.
+- Chatting with NPCs, such as teleporting to the Darkmoon Faire or starting some pet battles.
 
 In addition, it simplifies the following dialog:
 

--- a/Localization.lua
+++ b/Localization.lua
@@ -96,3 +96,6 @@ L["quest_shown"] = "Confirmation pop-up abandoning a " .. APR.Utilities.CHAT_RED
 
 L["workorder_hidden"] = "Confirmation pop-up when crafting a " .. APR.Utilities.CHAT_GREEN .. "workorder" .. FONT_COLOR_CODE_CLOSE .. " that uses your own reagents will be " .. APR.Utilities.CHAT_GREEN .. "hidden" .. FONT_COLOR_CODE_CLOSE .. "."
 L["workorder_shown"] = "Confirmation pop-up crafting a " .. APR.Utilities.CHAT_RED .. "workorder" .. FONT_COLOR_CODE_CLOSE .. " that uses your own reagents will be " .. APR.Utilities.CHAT_RED .. "shown" .. FONT_COLOR_CODE_CLOSE .. "."
+
+L["gossip_hidden"] = "Confirmation pop-up when " .. APR.Utilities.CHAT_GREEN .. "gossip" .. FONT_COLOR_CODE_CLOSE .. "ing with some NPCS will be " .. APR.Utilities.CHAT_GREEN .. "hidden" .. FONT_COLOR_CODE_CLOSE .. "."
+L["gossip_shown"] = "Confirmation pop-up when " .. APR.Utilities.CHAT_RED .. "gossip" .. FONT_COLOR_CODE_CLOSE .. "ing with some NPCS will be " .. APR.Utilities.CHAT_RED .. "shown" .. FONT_COLOR_CODE_CLOSE .. "."

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This add-on removes a number of annoying pop-ups.
 - Undercutting when selling an item on the auction house. (This is off by default - please don't undercut, it's not needed!)
 - Buying a dragonriding talent.
 - Crafting a profession work order using your own reagents or materials.
-- Requesting a teleport to the Darkmoon Faire from a Darkmoon Faire Mystic Mage.
+- Chatting with NPCs, such as teleporting to the Darkmoon Faire or starting some pet battles.
 
 In addition, it simplifies the following dialog:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This add-on removes a number of annoying pop-ups.
 - Undercutting when selling an item on the auction house. (This is off by default - please don't undercut, it's not needed!)
 - Buying a dragonriding talent.
 - Crafting a profession work order using your own reagents or materials.
+- Requesting a teleport to the Darkmoon Faire from a Darkmoon Faire Mystic Mage.
 
 In addition, it simplifies the following dialog:
 

--- a/WoWI description in BBCode.bbcode
+++ b/WoWI description in BBCode.bbcode
@@ -18,6 +18,7 @@ Ever get annoyed by those pop-ups in the game that make you feel like it's an ov
 [*]Abandoning a quest.
 [*]Buying a dragonriding talent.
 [*]Crafting a profession work order using your own reagents or materials.
+[*]Accepting a teleport to the Darkmoon Faire.
 [/LIST]
 
 In all cases, the add-on removes the dialog and makes the game think you clicked "Okay" to allow the action. That's it!
@@ -36,9 +37,9 @@ The easiest way to configure the addon is through the standard Blizzard addon in
 
 [SIZE="4"]Version Notes[/SIZE]
 
-Version 17 adds the option to hide the pop-up when crafting a profession work order using your own reagents or materials.
+Version 18 adds the option to hide the pop-up when you request a teleport to the Darkmoon Faire from a Darkmoon Faire Mystic Mage.
 
-Version 16 adds the option to hide the pop-up when abandoning a quest.
+Version 17 adds the option to hide the pop-up when crafting a profession work order using your own reagents or materials.
 
 So far, I've tested this add-on in a variety of situations, and it seems to work well for all scenarios I've encountered. If you encounter any errors, PLEASE [URL="https://github.com/KyrosKrane/AnnoyingPopupRemover/issues"]open an issue[/URL] on Github including the FULL error message and what you were doing when it happened. I also need to know whether you were solo, in a group, or in a raid; and what the group/raid loot settings were (e.g., master loot, NBG, etc., and what the loot threshold was).
 

--- a/WoWI description in BBCode.bbcode
+++ b/WoWI description in BBCode.bbcode
@@ -18,7 +18,7 @@ Ever get annoyed by those pop-ups in the game that make you feel like it's an ov
 [*]Abandoning a quest.
 [*]Buying a dragonriding talent.
 [*]Crafting a profession work order using your own reagents or materials.
-[*]Chatting with NPCs, such as teleporting to the Darkmoon Faire or starting some pet battles.
+[*]Chatting with NPCs, such as teleporting to the Darkmoon Faire, healing pets at a stable master, or starting pet battles.
 [/LIST]
 
 In all cases, the add-on removes the dialog and makes the game think you clicked "Okay" to allow the action. That's it!
@@ -44,6 +44,8 @@ Version 17 adds the option to hide the pop-up when crafting a profession work or
 So far, I've tested this add-on in a variety of situations, and it seems to work well for all scenarios I've encountered. If you encounter any errors, PLEASE [URL="https://github.com/KyrosKrane/AnnoyingPopupRemover/issues"]open an issue[/URL] on Github including the FULL error message and what you were doing when it happened. I also need to know whether you were solo, in a group, or in a raid; and what the group/raid loot settings were (e.g., master loot, NBG, etc., and what the loot threshold was).
 
 [SIZE="4"]Known errors[/SIZE]
+
+I tried to include the most common stable masters and pet battles, but I might have missed some. If you see a popup asking you to confirm healing your pets at a stable master or to confirm starting a pet battle, please report it in [URL="https://discord.gg/YRBDrxQ"]my Discord server[/URL]. I'll need to know your player faction (Horde/Alliance) and the name of the pet tamer or stable master you got the popup from.
 
 I've had reports that the addon can interfere with picking up bind-on-pickup items on Classic Era and Wrath Classic servers. Reported examples are fishing up Old Ironjaw or Old Crafty. I've never been able to reproduce this properly, so I don't know what the root cause is or how to fix it. If you are trying for those fish, I suggest disabling the options for looting bind-on-pickup items.
 

--- a/WoWI description in BBCode.bbcode
+++ b/WoWI description in BBCode.bbcode
@@ -18,7 +18,7 @@ Ever get annoyed by those pop-ups in the game that make you feel like it's an ov
 [*]Abandoning a quest.
 [*]Buying a dragonriding talent.
 [*]Crafting a profession work order using your own reagents or materials.
-[*]Accepting a teleport to the Darkmoon Faire.
+[*]Chatting with NPCs, such as teleporting to the Darkmoon Faire or starting some pet battles.
 [/LIST]
 
 In all cases, the add-on removes the dialog and makes the game think you clicked "Okay" to allow the action. That's it!

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -105,12 +105,18 @@ end -- HidePopup()
 -- List the gossip text strings that should be auto confirmed.
 -- format: GossipTextList["Blizzard text"] = "Name for use in APR"
 local GossipTextList = {}
-GossipTextList[L["Travel to the faire staging area will cost:"]] = "Darkmoon Faire" -- NOTE, this line (for the DMF) is not localized in Blizzard's lua code.
-
+-- Before I realized I could use the IDs to identify specific gossips, I tried using the text of the popup dialog.
+-- It works, but it's unreliable due to localization.
+-- So, while the code and infrastructure for it are still here, it shouldn't be used.
+-- Use the gossipID instead.
 
 -- Similarly track gossips by ID that should be auto confirmed.
 -- format: GossipIDList[gossipID] = "Name for use in APR"
 local GossipIDList = {}
+
+-- Darkmoon Faire teleports
+GossipIDList[40457] = "Darkmoon Faire Alliance" -- both alliance and horde gossips are shared across all the factional Mystic Mage NPCs
+GossipIDList[40007] = "Darkmoon Faire Horde"
 
 -- Eastern Kingdoms pet tamers
 GossipIDList[41781] = "Lydia Accoste" -- Deadwind Pass

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -164,7 +164,8 @@ GossipIDList[41155] = "Seeker Zusshi"
 GossipIDList[41822] = "Wastewalker Shu"
 
 -- Spawning rares and opening chests at suffusion camps
-GossipIDList[108274] = "Secured Shipment" -- loot chest
+GossipIDList[108274] = "Secured Shipment Azure Span" -- loot chest
+GossipIDList[109222] = "Secured Shipment Oh'naran Plains" -- loot chest
 GossipIDList[108249] = "Suffusion Crucible" -- spawns minor rares
 GossipIDList[108250] = "Suffusion Mold" -- spawns Forgemaster
 

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -36,8 +36,12 @@ APR.Modules[ThisModule].DBDefaultValue = APR.HIDE_DIALOG
 APR.Modules[ThisModule].config = {
 	name = L["Hide the confirmation pop-up for various NPC chats (English clients only)"],
 	type = "toggle",
-	set = function(info, val) APR:HandleAceSettingsChange(val, info) end,
-	get = function(info) return APR.DB.HideGossip end,
+	set = function(info, val)
+		APR:HandleAceSettingsChange(val, info)
+	end,
+	get = function(info)
+		return APR.DB.HideGossip
+	end,
 	descStyle = "inline",
 	width = "full",
 } -- config
@@ -60,7 +64,6 @@ APR.Modules[ThisModule].WorksInClassic = false
 -- This Boolean tells us whether to disable this module during combat. This can be deleted if it's false.
 APR.Modules[ThisModule].DisableInCombat = true -- Since this module is designed to handle multiple popups, I'm going to leave this as true to be safe.
 
-
 -- Since the gossip StaticPopup is shared among many chats, most of which we don't handle, we can't just nuke the entire popup.
 -- Instead, we just instantly confirm when it pops up for our selected events.
 
@@ -71,18 +74,29 @@ APR.Modules[ThisModule].ShowPopup = function(printconfirm)
 	-- Mark that the dialog is shown.
 	APR.DB.HideGossip = APR.SHOW_DIALOG
 
-	if printconfirm then APR:PrintStatus(ThisModule) end
+	if printconfirm then
+		APR:PrintStatus(ThisModule)
+	end
 end -- ShowPopup()
 
 
 -- This function causes the popup to be hidden when triggered.
 APR.Modules[ThisModule].HidePopup = function(printconfirm, ForceHide)
-	DebugPrint("in APR.Modules['" .. ThisModule .. "'].HidePopup, printconfirm is " .. MakeString(printconfirm ) .. ", ForceHide is " .. MakeString(ForceHide))
+	DebugPrint(
+		"in APR.Modules['"
+			.. ThisModule
+			.. "'].HidePopup, printconfirm is "
+			.. MakeString(printconfirm)
+			.. ", ForceHide is "
+			.. MakeString(ForceHide)
+	)
 
 	-- Mark that the dialog is hidden.
 	APR.DB.HideGossip = APR.HIDE_DIALOG
 
-	if printconfirm then APR:PrintStatus(ThisModule) end
+	if printconfirm then
+		APR:PrintStatus(ThisModule)
+	end
 end -- HidePopup()
 
 
@@ -111,9 +125,7 @@ GossipIDList[41822] = "Wastewalker Shu"
 -- Now capture the events that this module has to handle
 
 if not APR.IsClassic or APR.Modules[ThisModule].WorksInClassic then
-
 	function APR.Events:GOSSIP_CONFIRM(gossipID, text, cost)
-
 		DebugPrint("In APR.Events:GOSSIP_CONFIRM")
 
 		DebugPrint("gossipID is " .. gossipID)
@@ -143,14 +155,27 @@ if not APR.IsClassic or APR.Modules[ThisModule].WorksInClassic then
 
 				-- Check if the dialog ID is in the list of IDs we want to skip.
 				if sp_data and GossipIDList[sp_data] and sp_data == gossipID then
-					DebugPrint(string.format("Found matching popup by ID, index %d, ID %s, name is %s", i, sp_data, GossipIDList[sp_data]))
+					DebugPrint(
+						string.format(
+							"Found matching popup by ID, index %d, ID %s, name is %s",
+							i,
+							sp_data,
+							GossipIDList[sp_data]
+						)
+					)
 					StaticPopupDialogs["GOSSIP_CONFIRM"]:OnAccept(gossipID)
 
 					-- Check if the dialog has the specific text we want to auto approve
 				elseif sp_text and GossipTextList[sp_text] then
-					DebugPrint(string.format("Found matching popup by text, index %d, text %s, name %s", i, sp_text, GossipTextList[sp_text]))
+					DebugPrint(
+						string.format(
+							"Found matching popup by text, index %d, text %s, name %s",
+							i,
+							sp_text,
+							GossipTextList[sp_text]
+						)
+					)
 					StaticPopupDialogs["GOSSIP_CONFIRM"]:OnAccept(gossipID)
-
 				else
 					DebugPrint("Auto-confirm condition not met.")
 				end
@@ -164,7 +189,8 @@ if not APR.IsClassic or APR.Modules[ThisModule].WorksInClassic then
 		-- Direct command for Classic:
 		-- SelectGossipOption(data, "", true) -- need to figure out if data is just the gossipID again.
 
-
-		if not found then DebugPrint("Did not find matching popup") end
+		if not found then
+			DebugPrint("Did not find matching popup")
+		end
 	end -- APR.Events:GOSSIP_CONFIRM()
 end -- WoW Classic check

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -58,13 +58,12 @@ APR.Modules[ThisModule].shown_msg = L[ThisModule .. "_shown"]
 -- This Boolean tells us whether this module works in Classic.
 APR.Modules[ThisModule].WorksInClassic = false
 -- Although the Darkmoon Faire exists in classic, the teleport NPC does not.
--- Pet battles also don't exist in Classic.
+-- Pet battles and suffusion camps also don't exist in Classic.
 -- If I ever implement a gossip popup that exists in Classic, I'll have to review the code below.
 
 -- This Boolean tells us whether to disable this module during combat. This can be deleted if it's false.
 APR.Modules[ThisModule].DisableInCombat = false
--- I'm assuming none of these options will be combat affecting. Pet battles and DMF port will be fine, since the chance of those during combat is low.
--- Suffusion camp ones need more testing to be sure.
+-- I was never able to trigger an error using these during combat. I'm assuming it's fine.
 
 -- Since the gossip StaticPopup is shared among many chats, most of which we don't handle, we can't just nuke the entire popup.
 -- Instead, we just instantly confirm when it pops up for our selected events.
@@ -182,6 +181,7 @@ GossipIDList[108250] = "Suffusion Mold" -- spawns Forgemaster
 -- 36818 - Aiwen Ironeye, Theron's Watch, Azure Span
 -- 55630 - Goru the Shepherd, Forkriver Crossing, Ohn'ahran Plains
 -- 55630 - Beastmaster Oken, Broadhoof Outpost, Ohn'ahran Plains
+-- 36818 - Bulrug, Thunder Bluff, and Tassia Whisperglen, Dalaran Northrend
 
 
 -- Now capture the events that this module has to handle

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -97,13 +97,18 @@ local GossipConfirmTextList = {}
 GossipConfirmTextList[L["Travel to the faire staging area will cost:"]] = "Darkmoon Faire" -- NOTE, this is not localized in Blizzard's lua code.
 
 
-local function ConfirmGossip_DF()
-	DebugPrint("In ConfirmGossip_DF(), Executing C_PlayerInteractionManager commands")
-	C_PlayerInteractionManager.ConfirmationInteraction(Enum.PlayerInteractionType.Gossip)
-	C_PlayerInteractionManager.ClearInteraction(Enum.PlayerInteractionType.Gossip)
+local function ConfirmGossip_DF(gossipID)
+	DebugPrint(string.format("In ConfirmGossip_DF(), Executing C_PlayerInteractionManager commands using type %d", Enum.PlayerInteractionType.Gossip))
+	StaticPopupDialogs["GOSSIP_CONFIRM"]:OnAccept(gossipID)
+
+	-- Direct command for retail
+	-- C_GossipInfo.SelectOption(gossipID, "", true)
+
+	-- Direct command for Classic:
+	-- SelectGossipOption(data, "", true) -- need to figure out if data is just the gossipID again.
+
+	-- @TODO: figure out whether the OnAccept() call works as expected in Classic.
 end
-
-
 
 
 -- Now capture the events that this module has to handle
@@ -131,7 +136,7 @@ if not APR.IsClassic or APR.Modules[ThisModule].WorksInClassic then
 			if _G[sp_name] and _G[sp_name].text and _G[sp_name].text.text_arg1 and GossipConfirmTextList[_G[sp_name].text.text_arg1] then
 				DebugPrint(string.format("Found matching popup, index %d, type %s", i, GossipConfirmTextList[_G[sp_name].text.text_arg1]))
 
-				ConfirmGossip_DF()
+				ConfirmGossip_DF(gossipID)
 				return
 			end
 		end

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -154,9 +154,9 @@ if not APR.IsClassic or APR.Modules[ThisModule].WorksInClassic then
 				else
 					DebugPrint("Auto-confirm condition not met.")
 				end
-			end
-		end
-		
+			end -- if dialog shown
+		end -- for each dialog
+
 		-- Instead of calling OnAccept(), I could also call the direct commands.
 		-- Direct command for retail
 		-- C_GossipInfo.SelectOption(gossipID, "", true)

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -147,10 +147,18 @@ GossipIDList[41428] = "Kela Grimtotem" -- Thousand Needles
 GossipIDList[41246] = "Grazzle the Great" -- Dustwallow Marsh
 
 -- Outland pet tamers
-GossipIDList[00000] = "tbd" -- tbd
+GossipIDList[40903] = "Morulu the Elder" -- Shattrath
+GossipIDList[40903] = "Bloodknight Antari" -- Shadowmoon Valley
+GossipIDList[41046] = "Nicki Tinytech" -- Hellfire Peninsula
+GossipIDList[41751] = "Narrok" -- Nagrand
+GossipIDList[40901] = "Ras'an" -- Zangarmarsh
 
 -- Northrend pet tamers
-GossipIDList[00000] = "tbd" -- tbd
+GossipIDList[40769] = "Major Payne" -- Argent Tournament, Icecrown
+GossipIDList[41230] = "Nearly Headless Jacob" -- Crystalsong Forest
+GossipIDList[41234] = "Gutwretch" -- Zul'Drak
+GossipIDList[41232] = "Okrut Dragonwaste" -- Dragonblight
+GossipIDList[41228] = "Beegle Blastfuse" -- Howling Fjord
 
 -- Cataclysm pet tamers
 GossipIDList[41919] = "Obalis" -- Uldum
@@ -182,7 +190,8 @@ GossipIDList[108250] = "Suffusion Mold" -- spawns Forgemaster
 -- 55630 - Goru the Shepherd, Forkriver Crossing, Ohn'ahran Plains
 -- 55630 - Beastmaster Oken, Broadhoof Outpost, Ohn'ahran Plains
 -- 36818 - Bulrug, Thunder Bluff, and Tassia Whisperglen, Dalaran Northrend
-
+-- 41280 - Vanndual, Loamm, Zeralek Cavern
+-- Iskaara and Valdrakken dudes are free, no popup
 
 -- Now capture the events that this module has to handle
 

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -184,14 +184,12 @@ GossipIDList[109222] = "Secured Shipment Ohn'ahran Plains" -- loot chest
 GossipIDList[108249] = "Suffusion Crucible" -- spawns minor rares
 GossipIDList[108250] = "Suffusion Mold" -- spawns Forgemaster
 
--- maybe stable masters?
--- 107788 - Pan the Kind Hand in Apex Observatory, Waking Shores
--- 36818 - Aiwen Ironeye, Theron's Watch, Azure Span
--- 55630 - Goru the Shepherd, Forkriver Crossing, Ohn'ahran Plains
--- 55630 - Beastmaster Oken, Broadhoof Outpost, Ohn'ahran Plains
--- 36818 - Bulrug, Thunder Bluff, and Tassia Whisperglen, Dalaran Northrend
--- 41280 - Vanndual, Loamm, Zeralek Cavern
--- Iskaara and Valdrakken dudes are free, no popup
+-- Stable masters. This is a partial list of known IDs
+GossipIDList[107788] = "Stable master 107788"
+GossipIDList[36818] = "Stable master 36818"
+GossipIDList[55630] = "Stable master 55630"
+GossipIDList[41280] = "Stable master 41280"
+
 
 -- Now capture the events that this module has to handle
 

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -107,9 +107,51 @@ GossipTextList[L["Travel to the faire staging area will cost:"]] = "Darkmoon Fai
 
 
 -- Similarly track gossips by ID that should be auto confirmed.
+-- format: GossipIDList[gossipID] = "Name for use in APR"
 local GossipIDList = {}
 
--- Pandaria pet tamer battles
+-- Eastern Kingdoms pet tamers
+GossipIDList[41781] = "Lydia Accoste" -- Deadwind Pass
+GossipIDList[40127] = "Julia Stevens" -- Elwynn Forest
+GossipIDList[41437] = "Old MacDonald" -- Westfall
+GossipIDList[41186] = "Eric Davidson" -- Duskwood
+GossipIDList[41216] = "Bill Buckler" -- Cape of Stranglethorn
+GossipIDList[39601] = "Steven Lisbane" -- Northern Stranglethorn
+GossipIDList[41777] = "Everessa" -- Swamp of Sorrows
+GossipIDList[41184] = "Lindsay" -- Redridge Mountains
+GossipIDList[41779] = "Durin Darkhammer" -- Burning Steppes
+GossipIDList[41417] = "Kortas Darkhammer" -- Searing Gorge
+GossipIDList[41415] = "Deiza Plaguehorn" -- Western Plaguelands
+GossipIDList[41413] = "David Kosse" -- Hinterlands
+
+-- Kalimdor pet tamers
+GossipIDList[41403] = "Zunta" -- Durotar
+GossipIDList[47298] = "Crysa" -- North Barrens
+GossipIDList[41182] = "Dagra the Fierce" -- North Barrens
+GossipIDList[41411] = "Stone Cold Trixxy" -- Winterspring
+GossipIDList[41258] = "Elena Flutterfly" -- Moonglade
+GossipIDList[41250] = "Zoltan" -- Felwood
+GossipIDList[40737] = "Analynn" -- Ashenvale
+GossipIDList[40812] = "Zonya the Sadist" -- Stonetalon Mountains
+GossipIDList[41022] = "Merda Stonehoof" -- Desolace
+GossipIDList[41017] = "Traitor Gluk" -- Feralas
+GossipIDList[41260] = "Cassandra Kaboom" -- South Barrens
+GossipIDList[41428] = "Kela Grimtotem" -- Thousand Needles
+GossipIDList[41246] = "Grazzle the Great" -- Dustwallow Marsh
+
+-- Outland pet tamers
+GossipIDList[00000] = "tbd" -- tbd
+
+-- Northrend pet tamers
+GossipIDList[00000] = "tbd" -- tbd
+
+-- Cataclysm pet tamers
+GossipIDList[41919] = "Obalis" -- Uldum
+GossipIDList[41915] = "Brok" -- Mount Hyjal
+GossipIDList[41913] = "Bordin Steadyfist" -- Deepholm
+GossipIDList[41917] = "Goz Banefury" -- Twilight Highlands
+
+-- Pandaria pet tamers
 GossipIDList[41951] = "Burning Pandaren Spirit"
 GossipIDList[41935] = "Flowing Pandaren Spirit"
 GossipIDList[41955] = "Thundering Pandaren Spirit"
@@ -120,6 +162,11 @@ GossipIDList[41818] = "Farmer Nishi"
 GossipIDList[41814] = "Hyuna of the Shrines"
 GossipIDList[41155] = "Seeker Zusshi"
 GossipIDList[41822] = "Wastewalker Shu"
+
+-- Spawning rares and opening chests at suffusion camps
+GossipIDList[108274] = "Secured Shipment" -- loot chest
+GossipIDList[108249] = "Suffusion Crucible" -- spawns minor rares
+GossipIDList[108250] = "Suffusion Mold" -- spawns Forgemaster
 
 
 -- Now capture the events that this module has to handle

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -101,6 +101,10 @@ APR.Modules[ThisModule].HidePopup = function(printconfirm, ForceHide)
 end -- HidePopup()
 
 
+-- Sometimes when auto confirming, it requires a gold cost.
+-- This is the max amount (in copper pieces) to auto confirm.
+local MAX_COPPER = 50000 -- 5g
+
 -- List the gossip text strings that should be auto confirmed.
 -- format: GossipTextList["Blizzard text"] = "Name for use in APR"
 local GossipTextList = {}
@@ -238,9 +242,14 @@ if not APR.IsClassic or APR.Modules[ThisModule].WorksInClassic then
 							GossipIDList[sp_data]
 						)
 					)
+
+					if cost and cost > MAX_COPPER then
+						DebugPrint("Cost %s exceeds max amount of %s. Not auto confirming.", cost, MAX_COPPER)
+						return
+					end
 					StaticPopupDialogs["GOSSIP_CONFIRM"]:OnAccept(gossipID)
 
-					-- Check if the dialog has the specific text we want to auto approve
+				-- Check if the dialog has the specific text we want to auto approve
 				elseif sp_text and GossipTextList[sp_text] then
 					DebugPrint(
 						string.format(
@@ -250,6 +259,11 @@ if not APR.IsClassic or APR.Modules[ThisModule].WorksInClassic then
 							GossipTextList[sp_text]
 						)
 					)
+
+					if cost and cost > MAX_COPPER then
+						DebugPrint("Cost %s exceeds max amount of %s. Not auto confirming.", cost, MAX_COPPER)
+						return
+					end
 					StaticPopupDialogs["GOSSIP_CONFIRM"]:OnAccept(gossipID)
 				else
 					DebugPrint("Auto-confirm condition not met.")

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -53,9 +53,8 @@ APR.Modules[ThisModule].shown_msg = L[ThisModule .. "_shown"]
 
 -- This Boolean tells us whether this module works in Classic.
 APR.Modules[ThisModule].WorksInClassic = false
--- Although the Darkmoon Faire exists in classic and has a similar popup, this popup is handled differently. 
--- In Retail, it uses the C_Gossip API, which doesn't exist in Classic. I might have found a way to finesse this by just calling the dialog's OnAccept function.
--- The solution works fine in retail. This needs to be tested in Classic.
+-- Although the Darkmoon Faire exists in classic, the teleport NPC does not.
+-- If I ever implement a gossip popup that exists in Classic, I'll have to review the code below.
 
 -- This Boolean tells us whether to disable this module during combat. This can be deleted if it's false.
 APR.Modules[ThisModule].DisableInCombat = true -- Since this module is designed to handle multiple popups, I'm going to leave this as true to be safe.
@@ -89,7 +88,7 @@ end -- HidePopup()
 -- List the gossip text strings that should be auto confirmed.
 -- format: GossipConfirmTextList["Blizzard text"] = "Name for use in APR"
 local GossipConfirmTextList = {}
-GossipConfirmTextList[L["Travel to the faire staging area will cost:"]] = "Darkmoon Faire" -- NOTE, this is not localized in Blizzard's lua code.
+GossipConfirmTextList[L["Travel to the faire staging area will cost:"]] = "Darkmoon Faire" -- NOTE, this line (for the DMF) is not localized in Blizzard's lua code.
 
 
 -- Now capture the events that this module has to handle

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -62,7 +62,9 @@ APR.Modules[ThisModule].WorksInClassic = false
 -- If I ever implement a gossip popup that exists in Classic, I'll have to review the code below.
 
 -- This Boolean tells us whether to disable this module during combat. This can be deleted if it's false.
-APR.Modules[ThisModule].DisableInCombat = true -- Since this module is designed to handle multiple popups, I'm going to leave this as true to be safe.
+APR.Modules[ThisModule].DisableInCombat = false
+-- I'm assuming none of these options will be combat affecting. Pet battles and DMF port will be fine, since the chance of those during combat is low.
+-- Suffusion camp ones need more testing to be sure.
 
 -- Since the gossip StaticPopup is shared among many chats, most of which we don't handle, we can't just nuke the entire popup.
 -- Instead, we just instantly confirm when it pops up for our selected events.

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -190,9 +190,15 @@ if not APR.IsClassic or APR.Modules[ThisModule].WorksInClassic then
 	function APR.Events:GOSSIP_CONFIRM(gossipID, text, cost)
 		DebugPrint("In APR.Events:GOSSIP_CONFIRM")
 
-		DebugPrint("gossipID is " .. gossipID)
-		DebugPrint("text is " .. text)
-		DebugPrint("cost is " .. cost)
+		-- If the gossipID is nil or blank, then it's not a dialog we care about
+		if not gossipID or "" == gossipID then
+			DebugPrint("GossipID is nil or blank, not auto confirming")
+			return
+		end
+
+		DebugPrint("gossipID is ", gossipID)
+		DebugPrint("text is ", text)
+		DebugPrint("cost is ", cost)
 
 		-- If the user didn't ask us to hide this popup, just return.
 		if not APR.DB.HideGossip then

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -167,9 +167,15 @@ GossipIDList[41822] = "Wastewalker Shu"
 
 -- Spawning rares and opening chests at suffusion camps
 GossipIDList[108274] = "Secured Shipment Azure Span" -- loot chest
-GossipIDList[109222] = "Secured Shipment Oh'naran Plains" -- loot chest
+GossipIDList[109222] = "Secured Shipment Ohn'ahran Plains" -- loot chest
 GossipIDList[108249] = "Suffusion Crucible" -- spawns minor rares
 GossipIDList[108250] = "Suffusion Mold" -- spawns Forgemaster
+
+-- maybe stable masters?
+-- 107788 - Pan the Kind Hand in Apex Observatory, Waking Shores
+-- 36818 - Aiwen Ironeye, Theron's Watch, Azure Span
+-- 55630 - Goru the Shepherd, Forkriver Crossing, Ohn'ahran Plains
+-- 55630 - Beastmaster Oken, Broadhoof Outpost, Ohn'ahran Plains
 
 
 -- Now capture the events that this module has to handle

--- a/module_gossip.lua
+++ b/module_gossip.lua
@@ -1,0 +1,143 @@
+-- module_gossip.lua
+-- Written by KyrosKrane Sylvanblade (kyros@kyros.info)
+-- Copyright (c) 2023 KyrosKrane Sylvanblade
+-- Licensed under the MIT License, as per the included file.
+-- Addon version: @project-version@
+
+-- This file defines a module that APR can handle. Each module is one setting or popup.
+
+-- This module auto confirms a number of gossip popups that share a common static popup and event.
+
+-- Grab the WoW-defined addon folder name and storage table for our addon
+local addonName, APR = ...
+
+-- Upvalues for readability
+local DebugPrint = APR.Utilities.DebugPrint
+local ChatPrint = APR.Utilities.ChatPrint
+local MakeString = APR.Utilities.MakeString
+local L = APR.L
+
+
+--#########################################
+--# Module settings
+--#########################################
+
+-- Note the lowercase naming of modules. Makes it easier to pass status and settings around
+local ThisModule = "gossip"
+
+-- Set up the module
+APR.Modules[ThisModule] = {}
+
+-- the name of the variable in APR.DB and its default value
+APR.Modules[ThisModule].DBName = "HideGossip"
+APR.Modules[ThisModule].DBDefaultValue = APR.HIDE_DIALOG
+
+-- This is the config setup for AceConfig
+APR.Modules[ThisModule].config = {
+	name = L["Hide the confirmation pop-up for various NPC chats (English clients only)"],
+	type = "toggle",
+	set = function(info, val) APR:HandleAceSettingsChange(val, info) end,
+	get = function(info) return APR.DB.HideGossip end,
+	descStyle = "inline",
+	width = "full",
+} -- config
+
+-- Set the order based on the file inclusion order in the TOC
+APR.Modules[ThisModule].config.order = APR.NextOrdering
+APR.NextOrdering = APR.NextOrdering + 10
+
+-- These are the status strings that are printed to indicate whether it's off or on
+-- @TODO: Remember to add these localized strings to the localization file!
+APR.Modules[ThisModule].hidden_msg = L[ThisModule .. "_hidden"]
+APR.Modules[ThisModule].shown_msg = L[ThisModule .. "_shown"]
+
+-- This Boolean tells us whether this module works in Classic.
+APR.Modules[ThisModule].WorksInClassic = false
+-- Although the Darkmoon Faire exists in classic and has a similar popup, I tested this in Retail only. 
+-- In Retail, it uses the Player Interaction Manager, which doesn't exist in Classic.
+-- Given that Blizz is likely to bring these code updates to Classic at some point, I'm disinclined to take a toon into classic and figure out the right events to make it work there.
+
+-- This Boolean tells us whether to disable this module during combat. This can be deleted if it's false.
+APR.Modules[ThisModule].DisableInCombat = true -- Since this module is designed to handle multiple popups, I'm going to leave this as true to be safe.
+
+
+-- Since the gossip StaticPopup is shared among many chats, most of which we don't handle, we can't just nuke the entire popup. Instead, we just instantly confirm when it pops up for our selected events.
+
+-- This function causes the popup to show when triggered.
+APR.Modules[ThisModule].ShowPopup = function(printconfirm)
+	DebugPrint("in APR.Modules['" .. ThisModule .. "'].ShowPopup, printconfirm is " .. MakeString(printconfirm))
+
+	-- Mark that the dialog is shown.
+	APR.DB.HideGossip = APR.SHOW_DIALOG
+
+	if printconfirm then APR:PrintStatus(ThisModule) end
+end -- ShowPopup()
+
+
+-- This function causes the popup to be hidden when triggered.
+APR.Modules[ThisModule].HidePopup = function(printconfirm, ForceHide)
+	DebugPrint("in APR.Modules['" .. ThisModule .. "'].HidePopup, printconfirm is " .. MakeString(printconfirm ) .. ", ForceHide is " .. MakeString(ForceHide))
+
+	-- Mark that the dialog is hidden.
+	APR.DB.HideGossip = APR.HIDE_DIALOG
+
+	if printconfirm then APR:PrintStatus(ThisModule) end
+end -- HidePopup()
+
+
+-- This function executes before the addon has fully loaded. Use it to initialize any settings this module needs.
+-- This function can be safely deleted if not used by this module.
+APR.Modules[ThisModule].PreloadFunc = function()
+end
+
+
+-- List the gossip text strings that should be auto confirmed.
+local GossipConfirmTextList = {}
+-- format: GossipConfirmTextList["Blizzard text"] = "Name for use in APR"
+GossipConfirmTextList[L["Travel to the faire staging area will cost:"]] = "Darkmoon Faire" -- NOTE, this is not localized in Blizzard's lua code.
+
+
+local function ConfirmGossip_DF()
+	DebugPrint("In ConfirmGossip_DF(), Executing C_PlayerInteractionManager commands")
+	C_PlayerInteractionManager.ConfirmationInteraction(Enum.PlayerInteractionType.Gossip)
+	C_PlayerInteractionManager.ClearInteraction(Enum.PlayerInteractionType.Gossip)
+end
+
+
+
+
+-- Now capture the events that this module has to handle
+
+if not APR.IsClassic or APR.Modules[ThisModule].WorksInClassic then
+
+	function APR.Events:GOSSIP_CONFIRM(gossipID, text, cost)
+
+		DebugPrint("In APR.Events:GOSSIP_CONFIRM")
+
+		DebugPrint("gossipID is " .. gossipID)
+		DebugPrint("text is " .. text)
+		DebugPrint("cost is " .. cost)
+
+		-- If the user didn't ask us to hide this popup, just return.
+		if not APR.DB.HideGossip then
+			DebugPrint("HideGossip off, not auto confirming")
+			return
+		end
+
+		-- Loop through the static popup dialogs to find the one that matches what we need.
+		for i = 1, 9 do
+			local sp_name = "StaticPopup" .. i
+
+			if _G[sp_name] and _G[sp_name].text and _G[sp_name].text.text_arg1 and GossipConfirmTextList[_G[sp_name].text.text_arg1] then
+				DebugPrint(string.format("Found matching popup, index %d, type %s", i, GossipConfirmTextList[_G[sp_name].text.text_arg1]))
+
+				ConfirmGossip_DF()
+				return
+			end
+		end
+
+		DebugPrint("Did not find matching popup")
+
+	end -- APR.Events:GOSSIP_CONFIRM()
+
+end  -- WoW Classic check


### PR DESCRIPTION
Hides gossip popups for pet tamer battles, healing pets at a stable master, suffusion camp items, and Darkmoon Faire teleports