### PR TITLE
Fix for follower items

### DIFF
--- a/AnnoyingPopupRemover.toc
+++ b/AnnoyingPopupRemover.toc
@@ -9,7 +9,7 @@
 ## IconTexture: Interface\AddOns\AnnoyingPopupRemover\Media\thumbup.blp
 
 ## SavedVariablesPerCharacter: APR_DB
-## OptionalDeps: Blizzard_VoidStorageUI
+## OptionalDeps: Blizzard_VoidStorageUI, Blizzard_GarrisonTemplates
 
 ## X-Curse-Project-ID: 93154
 ## X-WoWI-ID: 23631

--- a/module_followers.lua
+++ b/module_followers.lua
@@ -119,17 +119,16 @@ if not APR.IsClassic or this.WorksInClassic then
 	-- Instead, you have to right click the item and THEN click the spell targeting cursor on the equipment slot.
 	-- This override stops the lua error from happening, at the cost of removing the ability to equip items by dropping them on the toon.
 
-	-- Force the default Garrison UI addon to load so we can override it
 	-- The code here is adapted from (as of the time of this writing) Blizzard_GarrisonTemplates\Blizzard_GarrisonSharedTemplates.lua in the definition of StaticPopupDialogs["CONFIRM_FOLLOWER_EQUIPMENT"].
 	StaticPopupDialogs["CONFIRM_FOLLOWER_EQUIPMENT"].OnAccept = function(self)
 		if (self.data.source == "spell") then
-			DebugPrint("Auto approving follower spell.")
+			DebugPrint("in CONFIRM_FOLLOWER_EQUIPMENT OnAccept, Auto approving follower spell.")
 			C_Garrison.CastSpellOnFollowerAbility(self.data.followerID, self.data.abilityID);
 		elseif (self.data.source == "item") then
 			-- In the default UI, if you pick up an item and click it on a follower, this branch is executed. But this function throws an error if called from an addon.
 			-- So, don't call it. :)
+			DebugPrint("in CONFIRM_FOLLOWER_EQUIPMENT OnAccept, Follower item use detected and blocked.")
 			-- C_Garrison.CastItemSpellOnFollowerAbility(self.data.followerID, self.data.abilityID);
-			DebugPrint("Follower item use detected and blocked.")
 		end
 	end
 

--- a/module_void.lua
+++ b/module_void.lua
@@ -105,18 +105,6 @@ this.HidePopup = function(printconfirm, ForceHide)
 end -- HidePopup()
 
 
--- This function executes before the addon has fully loaded. Use it to initialize any settings this module needs.
--- This function can be safely deleted if not used.
-this.PreloadFunc = function()
-		-- Future proof against upcoming API changes
-		local LoadAddOn = LoadAddOn or C_AddOns.LoadAddOn
-		-- Force the default Void Storage frame to load so we can override it
-		local isloaded, reason = LoadAddOn("Blizzard_VoidStorageUI")
-		DebugPrint("Blizzard_VoidStorageUI isloaded is " .. MakeString(isloaded))
-		DebugPrint("Blizzard_VoidStorageUI reason is " .. MakeString(reason))
-end
-
-
 -- Now capture the events that this module has to handle
 
 if not APR.IsClassic or this.WorksInClassic then


### PR DESCRIPTION
Equipping items on followers in garrison shipyards (ships), Legion mission tables, and BfA mission tables now requires right clicking the item then clicking the slot you want to use, to work around a Blizzard restriction. You can't pick up the item on your cursor, then drop it directly on the follower slot.